### PR TITLE
Fix an error in creating an entry from helm

### DIFF
--- a/helm-org-multi-wiki.el
+++ b/helm-org-multi-wiki.el
@@ -91,8 +91,8 @@ When FIRST is given, it is the default target of entry creation."
                                                (if (equal id first)
                                                    " (current)"
                                                  ""))
-                                       `(lambda (inp)
-                                          (org-multi-wiki-visit-entry inp :id ,id))))
+                                       (lambda (inp)
+                                         (org-multi-wiki-visit-entry inp :id id))))
                                (if (and first (> (length ids) 1))
                                    (cons first (-remove-item first ids))
                                  ids)))))))))


### PR DESCRIPTION
Fix an error like this:

Symbol’s value as variable is void: programming