### PR TITLE
Avoid an weird file path inside a symlinked root

### DIFF
--- a/org-multi-wiki.el
+++ b/org-multi-wiki.el
@@ -352,7 +352,8 @@ If FILE is omitted, the current buffer is assumed."
                org-multi-wiki-namespace-list)
          (list :file file
                :namespace namespace
-               :basename (file-relative-name sans-extension root-directory)))))
+               :basename (file-relative-name (file-truename sans-extension)
+                                             (file-truename root-directory))))))
 
 ;;;###autoload
 (defun org-multi-wiki-in-namespace-p (namespace &optional dir)


### PR DESCRIPTION
If the root directory is inside a symlinked directory, it could produce an weird file path with many `../`s. To avoid that issue, it is safer to retrieve the true names of the file and the root directory.