### PR TITLE
Add support for extra Org files

### DIFF
--- a/org-multi-wiki-tests.el
+++ b/org-multi-wiki-tests.el
@@ -95,3 +95,23 @@
             :to-equal "sample.txt")
     (expect (org-multi-wiki--strip-org-extension "hello.org.nonorg")
             :to-equal "hello.org.nonorg")))
+
+(describe "org-multi-wiki--extra-files"
+  (it "returns a flat list of file names"
+    ;; Note that I am going to remove notes.org in the future, so I
+    ;; will have to update this test case as well then.
+    (expect (let ((org-directory ".")
+                  (org-agenda-files (list "."))
+                  (org-multi-wiki-extra-files
+                   '("."
+                     "NON-EXISTENT-FILE"
+                     "NON-EXISTENT-DIR/"
+                     org-directory
+                     org-agenda-files)))
+              (org-multi-wiki--extra-files))
+            :to-equal
+            (->> (-map (lambda (f)
+                         (expand-file-name f default-directory))
+                       '("README.org" "notes.org"))
+                 (-repeat 3)
+                 (-flatten-n 1)))))


### PR DESCRIPTION
Added `org-multi-wiki-extra-files` custom variable. These files will be scanned for backlinks (which is not implemented yet) to the knowledge base from outside of the knowledge base.

`org-multi-wiki-extra-files` is now included in `helm-org-multi-wiki-all`. This feature can be turned off by setting `helm-org-multi-wiki-show-extra-files` to nil.