### PR TITLE
Initial support for backlinks

### DIFF
--- a/helm-org-multi-wiki.el
+++ b/helm-org-multi-wiki.el
@@ -422,15 +422,6 @@ If this variable is non-nil, `helm-org-multi-wiki-all' will get a
 `helm-org-ql' source for `org-multi-wiki-extra-files'."
   :type 'boolean)
 
-(defclass helm-org-multi-wiki-source-recent-entry (helm-org-multi-wiki-marker-source)
-  ((candidate-transformer
-    :initform (lambda (items)
-                (if helm-org-multi-wiki-recent-heading-limit
-                    (-take (min helm-org-multi-wiki-recent-heading-limit
-                                (length items))
-                           items)
-                  items)))))
-
 (defun helm-org-multi-wiki-recent-entry-candidates (namespaces)
   "Return a list of Helm candidates of recent headings from NAMESPACES."
   (let ((window-width (window-width (helm-window))))

--- a/org-multi-wiki.el
+++ b/org-multi-wiki.el
@@ -282,7 +282,7 @@ some functions in this package may return duplicates."
   :group 'org-multi-wiki)
 
 (defcustom org-multi-wiki-prefix-link-text t
-  "Whether to prefix the link text with the top-level heading."
+  "Whether to prefix the link text with a heading at the top level."
   :type 'boolean
   :group 'org-multi-wiki)
 
@@ -397,8 +397,8 @@ file name."
 
 ;;;; Modes
 ;;;###autoload
-(define-minor-mode org-multi-wiki-global-mode nil
-  nil nil nil
+(define-minor-mode org-multi-wiki-global-mode
+  "A global minor mode that should be turned on for the package."
   :global t
   :after-hook
   (cond
@@ -419,8 +419,7 @@ file name."
     (cl-delete (assoc "wiki" org-link-parameters) org-link-parameters))))
 
 (define-minor-mode org-multi-wiki-mode
-  "Minor mode that should be activated in all wiki buffers."
-  nil nil nil)
+  "Minor mode that should be activated in all wiki buffers.")
 
 ;;;; Configuration helpers
 ;;;###autoload
@@ -712,8 +711,7 @@ and DIR is the root directory of the namespace."
 If AS-BUFFERS is non-nil, this function returns a list of buffers.
 Otherwise, it returns a list of file names.
 
-It also tries to strip duplicates.
-"
+It also tries to strip duplicates."
   (cl-flet*
       ((expand-path
         (s)

--- a/org-multi-wiki.el
+++ b/org-multi-wiki.el
@@ -1328,6 +1328,12 @@ the source file."
                                              super-groups sort)
   "Display entries containing a backlink to the current entry.
 
+This is an experimental feature. Maybe I will drop this command
+in the future in favor of a transient command. I would recommend
+you to use `org-multi-wiki-backlink-query' and
+`org-multi-wiki-entry-files' for implemeting your own command,
+which are likely to supported in future releases.
+
 SCOPE must be a symbol which denotes the link target. The
 following values are supported:
 


### PR DESCRIPTION
This adds `org-multi-wiki-backlink-view ` command, which displays a list of entries containing a link to the current file/entry.

Note that this does not work until https://github.com/alphapapa/org-ql/pull/220 is merged.